### PR TITLE
feat: Add notification system for grow reminders

### DIFF
--- a/components/grow-detail-client.tsx
+++ b/components/grow-detail-client.tsx
@@ -9,7 +9,8 @@ import { PlantList } from "@/components/plant-list"
 import { FertilizerMixesManager } from "@/components/fertilizer-mixes"
 import { GrowInfo } from "@/components/grow-info"
 import { GrowDiary } from "@/components/grow-diary"
-import { Loader2, Home, ArrowLeft } from "lucide-react"
+import { ReminderList } from "@/components/notifications"
+import { Loader2, Home, ArrowLeft, Bell } from "lucide-react"
 import { getGrowById } from "@/lib/db"
 import { useToast } from "@/hooks/use-toast"
 import { Grow } from "@/lib/db"
@@ -179,7 +180,7 @@ export default function GrowDetailClient(props: GrowDetailClientProps) {
 
             <div className="relative">
                 <Tabs defaultValue="plants" className="w-full">
-                    <TabsList className="grid grid-cols-3 bg-gray-800 rounded-full">
+                    <TabsList className="grid grid-cols-4 bg-gray-800 rounded-full">
                         <TabsTrigger
                             value="plants"
                             className="data-[state=active]:bg-green-500 shadow-3xl shadow-green-500 data-[state=active]:text-gray-800 rounded-full"
@@ -197,6 +198,13 @@ export default function GrowDetailClient(props: GrowDetailClientProps) {
                             className="data-[state=active]:bg-green-500 shadow-3xl shadow-green-500 data-[state=active]:text-gray-800 rounded-full"
                         >
                             Mixes
+                        </TabsTrigger>
+                        <TabsTrigger
+                            value="reminders"
+                            className="data-[state=active]:bg-green-500 shadow-3xl shadow-green-500 data-[state=active]:text-gray-800 rounded-full"
+                        >
+                            <Bell className="h-4 w-4 mr-1" />
+                            Reminders
                         </TabsTrigger>
                     </TabsList>
 
@@ -218,6 +226,12 @@ export default function GrowDetailClient(props: GrowDetailClientProps) {
                             className="absolute top-0 left-0 w-full transition-opacity duration-300 opacity-100"
                         >
                             <FertilizerMixesManager growId={growId} />
+                        </TabsContent>
+                        <TabsContent
+                            value="reminders"
+                            className="absolute top-0 left-0 w-full transition-opacity duration-300 opacity-100"
+                        >
+                            <ReminderList growId={growId} growName={safeGrow.name} />
                         </TabsContent>
                     </div>
                 </Tabs>

--- a/components/notifications/NotificationSettings.tsx
+++ b/components/notifications/NotificationSettings.tsx
@@ -1,0 +1,225 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { Bell, BellOff, Volume2, VolumeX, Clock } from 'lucide-react';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Switch } from '@/components/ui/switch';
+import { Label } from '@/components/ui/label';
+import { Input } from '@/components/ui/input';
+import { useToast } from '@/components/ui/use-toast';
+import {
+    NotificationSettings as NotificationSettingsType,
+    getNotificationSettings,
+    saveNotificationSettings
+} from '@/lib/db';
+import {
+    isNotificationSupported,
+    requestNotificationPermission,
+    getNotificationPermission,
+    initializeNotifications,
+    stopNotifications
+} from '@/lib/notification-utils';
+
+export function NotificationSettings() {
+    const { toast } = useToast();
+    const [settings, setSettings] = useState<NotificationSettingsType | null>(null);
+    const [isLoading, setIsLoading] = useState(true);
+    const [isSupported, setIsSupported] = useState(false);
+
+    useEffect(() => {
+        const loadSettings = async () => {
+            setIsSupported(isNotificationSupported());
+            const current = await getNotificationSettings();
+            if (current) {
+                setSettings(current);
+            } else {
+                // Initialize with defaults
+                const defaults: NotificationSettingsType = {
+                    id: 'notification-settings',
+                    enabled: false,
+                    permission: getNotificationPermission(),
+                    defaultReminderTime: '09:00',
+                    soundEnabled: true
+                };
+                setSettings(defaults);
+            }
+            setIsLoading(false);
+        };
+        loadSettings();
+    }, []);
+
+    const handleEnableNotifications = async () => {
+        if (!settings) return;
+
+        if (settings.permission !== 'granted') {
+            const permission = await requestNotificationPermission();
+            if (permission !== 'granted') {
+                toast({
+                    title: 'Permission Denied',
+                    description: 'Please enable notifications in your browser settings.',
+                    variant: 'destructive'
+                });
+                return;
+            }
+            setSettings(prev => prev ? { ...prev, permission } : null);
+        }
+
+        const newEnabled = !settings.enabled;
+        await saveNotificationSettings({ enabled: newEnabled });
+        setSettings(prev => prev ? { ...prev, enabled: newEnabled } : null);
+
+        if (newEnabled) {
+            initializeNotifications();
+            toast({
+                title: 'Notifications Enabled',
+                description: 'You will now receive reminders for your grows.'
+            });
+        } else {
+            stopNotifications();
+            toast({
+                title: 'Notifications Disabled',
+                description: 'You will no longer receive reminders.'
+            });
+        }
+    };
+
+    const handleSoundToggle = async () => {
+        if (!settings) return;
+        const newSoundEnabled = !settings.soundEnabled;
+        await saveNotificationSettings({ soundEnabled: newSoundEnabled });
+        setSettings(prev => prev ? { ...prev, soundEnabled: newSoundEnabled } : null);
+    };
+
+    const handleTimeChange = async (time: string) => {
+        if (!settings) return;
+        await saveNotificationSettings({ defaultReminderTime: time });
+        setSettings(prev => prev ? { ...prev, defaultReminderTime: time } : null);
+    };
+
+    if (isLoading) {
+        return (
+            <Card>
+                <CardHeader>
+                    <CardTitle className="flex items-center gap-2">
+                        <Bell className="h-5 w-5" />
+                        Notifications
+                    </CardTitle>
+                </CardHeader>
+                <CardContent>
+                    <p className="text-muted-foreground">Loading...</p>
+                </CardContent>
+            </Card>
+        );
+    }
+
+    if (!isSupported) {
+        return (
+            <Card>
+                <CardHeader>
+                    <CardTitle className="flex items-center gap-2">
+                        <BellOff className="h-5 w-5" />
+                        Notifications
+                    </CardTitle>
+                </CardHeader>
+                <CardContent>
+                    <p className="text-muted-foreground">
+                        Notifications are not supported in this browser.
+                    </p>
+                </CardContent>
+            </Card>
+        );
+    }
+
+    return (
+        <Card>
+            <CardHeader>
+                <CardTitle className="flex items-center gap-2">
+                    <Bell className="h-5 w-5" />
+                    Notifications
+                </CardTitle>
+                <CardDescription>
+                    Configure reminders for watering, feeding, and more
+                </CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-6">
+                {/* Enable/Disable */}
+                <div className="flex items-center justify-between">
+                    <div className="space-y-0.5">
+                        <Label htmlFor="notifications-enabled">Enable Notifications</Label>
+                        <p className="text-sm text-muted-foreground">
+                            Receive browser notifications for reminders
+                        </p>
+                    </div>
+                    <Switch
+                        id="notifications-enabled"
+                        checked={settings?.enabled || false}
+                        onCheckedChange={handleEnableNotifications}
+                    />
+                </div>
+
+                {/* Permission Status */}
+                {settings?.permission === 'denied' && (
+                    <div className="rounded-md bg-destructive/10 p-3">
+                        <p className="text-sm text-destructive">
+                            Notifications are blocked. Please enable them in your browser settings.
+                        </p>
+                    </div>
+                )}
+
+                {/* Sound Toggle */}
+                <div className="flex items-center justify-between">
+                    <div className="flex items-center gap-2">
+                        {settings?.soundEnabled ? (
+                            <Volume2 className="h-4 w-4 text-muted-foreground" />
+                        ) : (
+                            <VolumeX className="h-4 w-4 text-muted-foreground" />
+                        )}
+                        <Label htmlFor="sound-enabled">Notification Sound</Label>
+                    </div>
+                    <Switch
+                        id="sound-enabled"
+                        checked={settings?.soundEnabled || false}
+                        onCheckedChange={handleSoundToggle}
+                        disabled={!settings?.enabled}
+                    />
+                </div>
+
+                {/* Default Time */}
+                <div className="space-y-2">
+                    <div className="flex items-center gap-2">
+                        <Clock className="h-4 w-4 text-muted-foreground" />
+                        <Label htmlFor="default-time">Default Reminder Time</Label>
+                    </div>
+                    <Input
+                        id="default-time"
+                        type="time"
+                        value={settings?.defaultReminderTime || '09:00'}
+                        onChange={(e) => handleTimeChange(e.target.value)}
+                        disabled={!settings?.enabled}
+                        className="w-32"
+                    />
+                    <p className="text-xs text-muted-foreground">
+                        New reminders will be scheduled around this time
+                    </p>
+                </div>
+
+                {/* Test Notification */}
+                {settings?.enabled && settings?.permission === 'granted' && (
+                    <Button
+                        variant="outline"
+                        size="sm"
+                        onClick={() => {
+                            new Notification('🌱 Test Notification', {
+                                body: 'Notifications are working correctly!',
+                                icon: '/icon-192x192.png'
+                            });
+                        }}
+                    >
+                        Send Test Notification
+                    </Button>
+                )}
+            </CardContent>
+        </Card>
+    );
+}

--- a/components/notifications/ReminderDialog.tsx
+++ b/components/notifications/ReminderDialog.tsx
@@ -1,0 +1,264 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { Droplets, Leaf, Camera, Scissors, Bell } from 'lucide-react';
+import {
+    Dialog,
+    DialogContent,
+    DialogDescription,
+    DialogFooter,
+    DialogHeader,
+    DialogTitle,
+} from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Textarea } from '@/components/ui/textarea';
+import {
+    Select,
+    SelectContent,
+    SelectItem,
+    SelectTrigger,
+    SelectValue,
+} from '@/components/ui/select';
+import { useToast } from '@/components/ui/use-toast';
+import { Reminder, ReminderType, saveReminder, generateId } from '@/lib/db';
+import { REMINDER_PRESETS, calculateNextDue } from '@/lib/notification-utils';
+
+const typeOptions: { value: ReminderType; label: string; icon: React.ReactNode }[] = [
+    { value: 'watering', label: 'Watering', icon: <Droplets className="h-4 w-4 text-blue-500" /> },
+    { value: 'feeding', label: 'Feeding', icon: <Leaf className="h-4 w-4 text-green-500" /> },
+    { value: 'photo', label: 'Photo', icon: <Camera className="h-4 w-4 text-purple-500" /> },
+    { value: 'training', label: 'Training', icon: <Scissors className="h-4 w-4 text-orange-500" /> },
+    { value: 'custom', label: 'Custom', icon: <Bell className="h-4 w-4 text-gray-500" /> },
+];
+
+interface ReminderDialogProps {
+    open: boolean;
+    onClose: () => void;
+    growId: string;
+    reminder?: Reminder;
+}
+
+export function ReminderDialog({ open, onClose, growId, reminder }: ReminderDialogProps) {
+    const { toast } = useToast();
+    const [type, setType] = useState<ReminderType>('watering');
+    const [title, setTitle] = useState('');
+    const [description, setDescription] = useState('');
+    const [intervalDays, setIntervalDays] = useState('2');
+    const [isSubmitting, setIsSubmitting] = useState(false);
+
+    const isEditing = !!reminder;
+
+    useEffect(() => {
+        if (reminder) {
+            setType(reminder.type);
+            setTitle(reminder.title);
+            setDescription(reminder.description || '');
+            setIntervalDays(reminder.intervalDays.toString());
+        } else {
+            // Reset to defaults for new reminder
+            setType('watering');
+            setTitle('');
+            setDescription('');
+            setIntervalDays('2');
+        }
+    }, [reminder, open]);
+
+    // Apply preset when type changes (only for new reminders)
+    useEffect(() => {
+        if (!isEditing && type !== 'custom') {
+            const preset = REMINDER_PRESETS[type as keyof typeof REMINDER_PRESETS];
+            if (preset) {
+                setTitle(preset.title);
+                setDescription(preset.description);
+                setIntervalDays(preset.intervalDays.toString());
+            }
+        }
+    }, [type, isEditing]);
+
+    const handleSubmit = async () => {
+        if (!title.trim()) {
+            toast({
+                title: 'Title Required',
+                description: 'Please enter a title for the reminder',
+                variant: 'destructive'
+            });
+            return;
+        }
+
+        const interval = parseInt(intervalDays, 10);
+        if (isNaN(interval) || interval < 0) {
+            toast({
+                title: 'Invalid Interval',
+                description: 'Please enter a valid interval (0 or more days)',
+                variant: 'destructive'
+            });
+            return;
+        }
+
+        setIsSubmitting(true);
+
+        try {
+            const now = new Date().toISOString();
+            const reminderData: Reminder = {
+                id: reminder?.id || generateId(),
+                growId,
+                plantId: reminder?.plantId,
+                type,
+                title: title.trim(),
+                description: description.trim() || undefined,
+                intervalDays: interval,
+                lastTriggered: reminder?.lastTriggered,
+                nextDue: reminder?.nextDue || calculateNextDue(interval),
+                enabled: reminder?.enabled ?? true,
+                createdAt: reminder?.createdAt || now,
+                updatedAt: now
+            };
+
+            await saveReminder(reminderData);
+            
+            toast({
+                title: isEditing ? 'Reminder Updated' : 'Reminder Created',
+                description: `"${title}" has been ${isEditing ? 'updated' : 'scheduled'}`
+            });
+            
+            onClose();
+        } catch (error) {
+            console.error('Failed to save reminder:', error);
+            toast({
+                title: 'Error',
+                description: 'Failed to save reminder',
+                variant: 'destructive'
+            });
+        } finally {
+            setIsSubmitting(false);
+        }
+    };
+
+    return (
+        <Dialog open={open} onOpenChange={(isOpen) => !isOpen && onClose()}>
+            <DialogContent className="sm:max-w-[425px]">
+                <DialogHeader>
+                    <DialogTitle>
+                        {isEditing ? 'Edit Reminder' : 'Create Reminder'}
+                    </DialogTitle>
+                    <DialogDescription>
+                        {isEditing 
+                            ? 'Update your reminder settings'
+                            : 'Set up a recurring reminder for your grow'
+                        }
+                    </DialogDescription>
+                </DialogHeader>
+                
+                <div className="space-y-4 py-4">
+                    {/* Type Selection */}
+                    <div className="space-y-2">
+                        <Label htmlFor="type">Type</Label>
+                        <Select value={type} onValueChange={(v) => setType(v as ReminderType)}>
+                            <SelectTrigger>
+                                <SelectValue />
+                            </SelectTrigger>
+                            <SelectContent>
+                                {typeOptions.map((option) => (
+                                    <SelectItem key={option.value} value={option.value}>
+                                        <div className="flex items-center gap-2">
+                                            {option.icon}
+                                            {option.label}
+                                        </div>
+                                    </SelectItem>
+                                ))}
+                            </SelectContent>
+                        </Select>
+                    </div>
+
+                    {/* Title */}
+                    <div className="space-y-2">
+                        <Label htmlFor="title">Title</Label>
+                        <Input
+                            id="title"
+                            value={title}
+                            onChange={(e) => setTitle(e.target.value)}
+                            placeholder="e.g., Water your plants"
+                        />
+                    </div>
+
+                    {/* Description */}
+                    <div className="space-y-2">
+                        <Label htmlFor="description">Description (optional)</Label>
+                        <Textarea
+                            id="description"
+                            value={description}
+                            onChange={(e) => setDescription(e.target.value)}
+                            placeholder="Additional details..."
+                            rows={2}
+                        />
+                    </div>
+
+                    {/* Interval */}
+                    <div className="space-y-2">
+                        <Label htmlFor="interval">Repeat Every (days)</Label>
+                        <div className="flex items-center gap-2">
+                            <Input
+                                id="interval"
+                                type="number"
+                                min="0"
+                                value={intervalDays}
+                                onChange={(e) => setIntervalDays(e.target.value)}
+                                className="w-24"
+                            />
+                            <span className="text-sm text-muted-foreground">
+                                {intervalDays === '0' ? '(one-time)' : 'days'}
+                            </span>
+                        </div>
+                        <p className="text-xs text-muted-foreground">
+                            Set to 0 for a one-time reminder
+                        </p>
+                    </div>
+
+                    {/* Quick Presets */}
+                    {!isEditing && (
+                        <div className="space-y-2">
+                            <Label>Quick Presets</Label>
+                            <div className="flex flex-wrap gap-2">
+                                <Button
+                                    variant="outline"
+                                    size="sm"
+                                    onClick={() => setIntervalDays('1')}
+                                    className={intervalDays === '1' ? 'border-primary' : ''}
+                                >
+                                    Daily
+                                </Button>
+                                <Button
+                                    variant="outline"
+                                    size="sm"
+                                    onClick={() => setIntervalDays('2')}
+                                    className={intervalDays === '2' ? 'border-primary' : ''}
+                                >
+                                    Every 2 days
+                                </Button>
+                                <Button
+                                    variant="outline"
+                                    size="sm"
+                                    onClick={() => setIntervalDays('7')}
+                                    className={intervalDays === '7' ? 'border-primary' : ''}
+                                >
+                                    Weekly
+                                </Button>
+                            </div>
+                        </div>
+                    )}
+                </div>
+
+                <DialogFooter>
+                    <Button variant="outline" onClick={onClose}>
+                        Cancel
+                    </Button>
+                    <Button onClick={handleSubmit} disabled={isSubmitting}>
+                        {isSubmitting ? 'Saving...' : isEditing ? 'Update' : 'Create'}
+                    </Button>
+                </DialogFooter>
+            </DialogContent>
+        </Dialog>
+    );
+}

--- a/components/notifications/ReminderList.tsx
+++ b/components/notifications/ReminderList.tsx
@@ -1,0 +1,315 @@
+'use client';
+
+import { useState, useEffect, useCallback } from 'react';
+import { 
+    Bell, 
+    Droplets, 
+    Leaf, 
+    Camera, 
+    Scissors, 
+    Plus,
+    Trash2,
+    Clock,
+    ToggleLeft,
+    ToggleRight
+} from 'lucide-react';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { useToast } from '@/components/ui/use-toast';
+import {
+    AlertDialog,
+    AlertDialogAction,
+    AlertDialogCancel,
+    AlertDialogContent,
+    AlertDialogDescription,
+    AlertDialogFooter,
+    AlertDialogHeader,
+    AlertDialogTitle,
+} from '@/components/ui/alert-dialog';
+import {
+    Reminder,
+    ReminderType,
+    getRemindersForGrow,
+    saveReminder,
+    deleteReminder
+} from '@/lib/db';
+import { ReminderDialog } from './ReminderDialog';
+
+const typeIcons: Record<ReminderType, React.ReactNode> = {
+    watering: <Droplets className="h-4 w-4 text-blue-500" />,
+    feeding: <Leaf className="h-4 w-4 text-green-500" />,
+    photo: <Camera className="h-4 w-4 text-purple-500" />,
+    training: <Scissors className="h-4 w-4 text-orange-500" />,
+    custom: <Bell className="h-4 w-4 text-gray-500" />
+};
+
+const typeLabels: Record<ReminderType, string> = {
+    watering: 'Watering',
+    feeding: 'Feeding',
+    photo: 'Photo',
+    training: 'Training',
+    custom: 'Custom'
+};
+
+interface ReminderListProps {
+    growId: string;
+    growName?: string;
+}
+
+export function ReminderList({ growId, growName }: ReminderListProps) {
+    const { toast } = useToast();
+    const [reminders, setReminders] = useState<Reminder[]>([]);
+    const [isLoading, setIsLoading] = useState(true);
+    const [dialogOpen, setDialogOpen] = useState(false);
+    const [editingReminder, setEditingReminder] = useState<Reminder | undefined>();
+    const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
+    const [reminderToDelete, setReminderToDelete] = useState<string | null>(null);
+
+    const loadReminders = useCallback(async () => {
+        try {
+            const data = await getRemindersForGrow(growId);
+            // Sort by next due date
+            data.sort((a, b) => new Date(a.nextDue).getTime() - new Date(b.nextDue).getTime());
+            setReminders(data);
+        } catch (error) {
+            console.error('Failed to load reminders:', error);
+            toast({
+                title: 'Error',
+                description: 'Failed to load reminders',
+                variant: 'destructive'
+            });
+        } finally {
+            setIsLoading(false);
+        }
+    }, [growId, toast]);
+
+    useEffect(() => {
+        loadReminders();
+    }, [loadReminders]);
+
+    const handleToggleEnabled = async (reminder: Reminder) => {
+        try {
+            const updated = { ...reminder, enabled: !reminder.enabled };
+            await saveReminder(updated);
+            setReminders(prev => prev.map(r => r.id === reminder.id ? updated : r));
+            toast({
+                title: updated.enabled ? 'Reminder Enabled' : 'Reminder Disabled',
+                description: `"${reminder.title}" is now ${updated.enabled ? 'active' : 'paused'}`
+            });
+        } catch (error) {
+            console.error('Failed to toggle reminder:', error);
+            toast({
+                title: 'Error',
+                description: 'Failed to update reminder',
+                variant: 'destructive'
+            });
+        }
+    };
+
+    const handleDelete = async () => {
+        if (!reminderToDelete) return;
+        
+        try {
+            await deleteReminder(reminderToDelete);
+            setReminders(prev => prev.filter(r => r.id !== reminderToDelete));
+            toast({
+                title: 'Reminder Deleted',
+                description: 'The reminder has been removed'
+            });
+        } catch (error) {
+            console.error('Failed to delete reminder:', error);
+            toast({
+                title: 'Error',
+                description: 'Failed to delete reminder',
+                variant: 'destructive'
+            });
+        } finally {
+            setDeleteDialogOpen(false);
+            setReminderToDelete(null);
+        }
+    };
+
+    const handleEdit = (reminder: Reminder) => {
+        setEditingReminder(reminder);
+        setDialogOpen(true);
+    };
+
+    const handleAddNew = () => {
+        setEditingReminder(undefined);
+        setDialogOpen(true);
+    };
+
+    const handleDialogClose = () => {
+        setDialogOpen(false);
+        setEditingReminder(undefined);
+        loadReminders();
+    };
+
+    const formatNextDue = (dateString: string): string => {
+        const date = new Date(dateString);
+        const now = new Date();
+        const diffMs = date.getTime() - now.getTime();
+        const diffHours = Math.floor(diffMs / (1000 * 60 * 60));
+        const diffDays = Math.floor(diffHours / 24);
+
+        if (diffMs < 0) {
+            return 'Overdue';
+        } else if (diffHours < 1) {
+            return 'Due soon';
+        } else if (diffHours < 24) {
+            return `In ${diffHours}h`;
+        } else if (diffDays === 1) {
+            return 'Tomorrow';
+        } else {
+            return `In ${diffDays} days`;
+        }
+    };
+
+    const getDueBadgeClass = (dateString: string): string => {
+        const date = new Date(dateString);
+        const now = new Date();
+        const diffMs = date.getTime() - now.getTime();
+        const diffHours = diffMs / (1000 * 60 * 60);
+
+        const baseClass = 'inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-semibold';
+        if (diffMs < 0) return `${baseClass} bg-red-500/20 text-red-400`;
+        if (diffHours < 24) return `${baseClass} bg-green-500/20 text-green-400`;
+        return `${baseClass} bg-gray-500/20 text-gray-400`;
+    };
+
+    if (isLoading) {
+        return (
+            <Card>
+                <CardHeader>
+                    <CardTitle className="flex items-center gap-2">
+                        <Bell className="h-5 w-5" />
+                        Reminders
+                    </CardTitle>
+                </CardHeader>
+                <CardContent>
+                    <p className="text-muted-foreground">Loading...</p>
+                </CardContent>
+            </Card>
+        );
+    }
+
+    return (
+        <>
+            <Card>
+                <CardHeader>
+                    <div className="flex items-center justify-between">
+                        <div>
+                            <CardTitle className="flex items-center gap-2">
+                                <Bell className="h-5 w-5" />
+                                Reminders
+                            </CardTitle>
+                            <CardDescription>
+                                {growName ? `Reminders for ${growName}` : 'Manage your grow reminders'}
+                            </CardDescription>
+                        </div>
+                        <Button size="sm" onClick={handleAddNew}>
+                            <Plus className="h-4 w-4 mr-1" />
+                            Add Reminder
+                        </Button>
+                    </div>
+                </CardHeader>
+                <CardContent>
+                    {reminders.length === 0 ? (
+                        <div className="text-center py-8 text-muted-foreground">
+                            <Bell className="h-12 w-12 mx-auto mb-4 opacity-20" />
+                            <p>No reminders yet</p>
+                            <p className="text-sm">Create reminders to stay on top of your grow</p>
+                        </div>
+                    ) : (
+                        <div className="space-y-3">
+                            {reminders.map((reminder) => (
+                                <div
+                                    key={reminder.id}
+                                    className={`flex items-center justify-between p-3 rounded-lg border ${
+                                        reminder.enabled ? 'bg-card' : 'bg-muted/50 opacity-60'
+                                    }`}
+                                >
+                                    <div className="flex items-center gap-3">
+                                        {typeIcons[reminder.type]}
+                                        <div>
+                                            <div className="font-medium">{reminder.title}</div>
+                                            <div className="text-sm text-muted-foreground flex items-center gap-2">
+                                                <span className="inline-flex items-center rounded-full border border-gray-600 px-2 py-0.5 text-xs">
+                                                    {typeLabels[reminder.type]}
+                                                </span>
+                                                {reminder.intervalDays > 0 && (
+                                                    <span className="flex items-center gap-1">
+                                                        <Clock className="h-3 w-3" />
+                                                        Every {reminder.intervalDays}d
+                                                    </span>
+                                                )}
+                                            </div>
+                                        </div>
+                                    </div>
+                                    <div className="flex items-center gap-2">
+                                        {reminder.enabled && (
+                                            <span className={getDueBadgeClass(reminder.nextDue)}>
+                                                {formatNextDue(reminder.nextDue)}
+                                            </span>
+                                        )}
+                                        <Button
+                                            variant="ghost"
+                                            size="icon"
+                                            onClick={() => handleToggleEnabled(reminder)}
+                                            title={reminder.enabled ? 'Disable' : 'Enable'}
+                                        >
+                                            {reminder.enabled ? (
+                                                <ToggleRight className="h-4 w-4 text-green-500" />
+                                            ) : (
+                                                <ToggleLeft className="h-4 w-4" />
+                                            )}
+                                        </Button>
+                                        <Button
+                                            variant="ghost"
+                                            size="icon"
+                                            onClick={() => handleEdit(reminder)}
+                                        >
+                                            <Clock className="h-4 w-4" />
+                                        </Button>
+                                        <Button
+                                            variant="ghost"
+                                            size="icon"
+                                            onClick={() => {
+                                                setReminderToDelete(reminder.id);
+                                                setDeleteDialogOpen(true);
+                                            }}
+                                        >
+                                            <Trash2 className="h-4 w-4 text-destructive" />
+                                        </Button>
+                                    </div>
+                                </div>
+                            ))}
+                        </div>
+                    )}
+                </CardContent>
+            </Card>
+
+            <ReminderDialog
+                open={dialogOpen}
+                onClose={handleDialogClose}
+                growId={growId}
+                reminder={editingReminder}
+            />
+
+            <AlertDialog open={deleteDialogOpen} onOpenChange={setDeleteDialogOpen}>
+                <AlertDialogContent>
+                    <AlertDialogHeader>
+                        <AlertDialogTitle>Delete Reminder?</AlertDialogTitle>
+                        <AlertDialogDescription>
+                            This action cannot be undone. The reminder will be permanently deleted.
+                        </AlertDialogDescription>
+                    </AlertDialogHeader>
+                    <AlertDialogFooter>
+                        <AlertDialogCancel>Cancel</AlertDialogCancel>
+                        <AlertDialogAction onClick={handleDelete}>Delete</AlertDialogAction>
+                    </AlertDialogFooter>
+                </AlertDialogContent>
+            </AlertDialog>
+        </>
+    );
+}

--- a/components/notifications/index.ts
+++ b/components/notifications/index.ts
@@ -1,0 +1,3 @@
+export { NotificationSettings } from './NotificationSettings';
+export { ReminderList } from './ReminderList';
+export { ReminderDialog } from './ReminderDialog';

--- a/components/settings.tsx
+++ b/components/settings.tsx
@@ -26,6 +26,7 @@ import { useRouting } from '@/hooks/useRouting';
 import { ExportImportSection } from '@/components/export-import-dialog';
 import { DLICalculator } from '@/components/dli-calculator';
 import HarvestCalculator from '@/components/harvest-calculator/HarvestCalculator';
+import { NotificationSettings } from '@/components/notifications';
 
 const sensorTypes = [
     'Lamp',
@@ -1028,6 +1029,9 @@ export default function SettingsPage() {
                             <HarvestCalculator />
                         </CardContent>
                     </Card>
+
+                    {/* Notifications Section */}
+                    <NotificationSettings />
 
                     <Card className="bg-gray-800/50 backdrop-filter backdrop-blur-lg border border-gray-700 rounded-2xl text-left">
                         <CardHeader>

--- a/lib/notification-utils.ts
+++ b/lib/notification-utils.ts
@@ -1,0 +1,332 @@
+/**
+ * Notification utilities for GrowPanion reminder system
+ * Handles browser notifications, permission management, and reminder scheduling
+ */
+
+import { 
+    Reminder, 
+    ReminderType,
+    NotificationSettings,
+    getNotificationSettings, 
+    saveNotificationSettings,
+    getAllReminders,
+    saveReminder,
+    generateId
+} from './db';
+
+// ============== NOTIFICATION PERMISSION ==============
+
+/**
+ * Check if browser supports notifications
+ */
+export function isNotificationSupported(): boolean {
+    return typeof window !== 'undefined' && 'Notification' in window;
+}
+
+/**
+ * Get current notification permission status
+ */
+export function getNotificationPermission(): NotificationPermission {
+    if (!isNotificationSupported()) return 'denied';
+    return Notification.permission;
+}
+
+/**
+ * Request notification permission from user
+ * @returns The resulting permission state
+ */
+export async function requestNotificationPermission(): Promise<NotificationPermission> {
+    if (!isNotificationSupported()) {
+        console.warn('Notifications are not supported in this browser');
+        return 'denied';
+    }
+
+    try {
+        const permission = await Notification.requestPermission();
+        await saveNotificationSettings({ permission });
+        return permission;
+    } catch (error) {
+        console.error('Failed to request notification permission:', error);
+        return 'denied';
+    }
+}
+
+// ============== NOTIFICATION DISPLAY ==============
+
+/**
+ * Show a browser notification
+ */
+export function showNotification(
+    title: string,
+    options?: NotificationOptions & { onClick?: () => void }
+): Notification | null {
+    if (!isNotificationSupported() || Notification.permission !== 'granted') {
+        console.warn('Cannot show notification: permission not granted');
+        return null;
+    }
+
+    try {
+        const notification = new Notification(title, {
+            icon: '/icon-192x192.png',
+            badge: '/icon-192x192.png',
+            ...options,
+        });
+
+        if (options?.onClick) {
+            notification.onclick = () => {
+                options.onClick?.();
+                notification.close();
+            };
+        }
+
+        return notification;
+    } catch (error) {
+        console.error('Failed to show notification:', error);
+        return null;
+    }
+}
+
+/**
+ * Show a reminder notification
+ */
+export function showReminderNotification(reminder: Reminder): Notification | null {
+    const typeIcons: Record<ReminderType, string> = {
+        watering: '💧',
+        feeding: '🌱',
+        photo: '📸',
+        training: '✂️',
+        custom: '🔔'
+    };
+
+    const icon = typeIcons[reminder.type] || '🔔';
+    
+    return showNotification(`${icon} ${reminder.title}`, {
+        body: reminder.description || `Time for ${reminder.type}!`,
+        tag: reminder.id,
+        requireInteraction: true,
+    });
+}
+
+// ============== REMINDER SCHEDULING ==============
+
+/**
+ * Calculate next due date for a reminder
+ * @param intervalDays Days between reminders (0 = one-time, don't reschedule)
+ * @param preferredTime Optional preferred time in HH:MM format
+ */
+export function calculateNextDue(intervalDays: number, preferredTime?: string): string {
+    const now = new Date();
+    const next = new Date(now);
+    
+    if (intervalDays > 0) {
+        next.setDate(next.getDate() + intervalDays);
+    }
+    
+    // Set preferred time if provided
+    if (preferredTime) {
+        const [hours, minutes] = preferredTime.split(':').map(Number);
+        next.setHours(hours, minutes, 0, 0);
+    }
+    
+    return next.toISOString();
+}
+
+/**
+ * Mark reminder as triggered and calculate next due date
+ */
+export async function triggerReminder(reminder: Reminder): Promise<Reminder> {
+    const now = new Date().toISOString();
+    const settings = await getNotificationSettings();
+    
+    const updatedReminder: Reminder = {
+        ...reminder,
+        lastTriggered: now,
+        // If interval is 0 (one-time), disable the reminder
+        enabled: reminder.intervalDays > 0,
+        nextDue: reminder.intervalDays > 0 
+            ? calculateNextDue(reminder.intervalDays, settings?.defaultReminderTime)
+            : reminder.nextDue,
+        updatedAt: now
+    };
+    
+    await saveReminder(updatedReminder);
+    return updatedReminder;
+}
+
+/**
+ * Create a new reminder
+ */
+export async function createReminder(
+    growId: string,
+    type: ReminderType,
+    title: string,
+    intervalDays: number,
+    options?: {
+        plantId?: string;
+        description?: string;
+        preferredTime?: string;
+    }
+): Promise<Reminder> {
+    const now = new Date().toISOString();
+    const settings = await getNotificationSettings();
+    const preferredTime = options?.preferredTime || settings?.defaultReminderTime || '09:00';
+    
+    const reminder: Reminder = {
+        id: generateId(),
+        growId,
+        plantId: options?.plantId,
+        type,
+        title,
+        description: options?.description,
+        intervalDays,
+        nextDue: calculateNextDue(intervalDays, preferredTime),
+        enabled: true,
+        createdAt: now,
+        updatedAt: now
+    };
+    
+    await saveReminder(reminder);
+    return reminder;
+}
+
+// ============== REMINDER CHECKING ==============
+
+/**
+ * Check for due reminders and show notifications
+ * Should be called periodically (e.g., every minute or on app focus)
+ */
+export async function checkDueReminders(): Promise<Reminder[]> {
+    const settings = await getNotificationSettings();
+    
+    // Don't check if notifications are disabled
+    if (!settings?.enabled || Notification.permission !== 'granted') {
+        return [];
+    }
+    
+    const allReminders = await getAllReminders();
+    const now = new Date();
+    
+    const dueReminders = allReminders.filter(reminder => {
+        if (!reminder.enabled) return false;
+        const dueDate = new Date(reminder.nextDue);
+        return dueDate <= now;
+    });
+    
+    // Show notifications for due reminders
+    for (const reminder of dueReminders) {
+        showReminderNotification(reminder);
+        await triggerReminder(reminder);
+    }
+    
+    return dueReminders;
+}
+
+// ============== REMINDER PRESETS ==============
+
+/**
+ * Common reminder presets for quick setup
+ */
+export const REMINDER_PRESETS = {
+    watering: {
+        type: 'watering' as ReminderType,
+        title: 'Water your plants',
+        description: 'Check soil moisture and water if needed',
+        intervalDays: 2
+    },
+    feeding: {
+        type: 'feeding' as ReminderType,
+        title: 'Feed your plants',
+        description: 'Time for nutrients',
+        intervalDays: 7
+    },
+    photo: {
+        type: 'photo' as ReminderType,
+        title: 'Document your grow',
+        description: 'Take photos for your grow diary',
+        intervalDays: 3
+    },
+    training: {
+        type: 'training' as ReminderType,
+        title: 'Check training',
+        description: 'Inspect LST/HST progress and adjust if needed',
+        intervalDays: 2
+    }
+} as const;
+
+/**
+ * Create reminders from a preset
+ */
+export async function createReminderFromPreset(
+    growId: string,
+    presetKey: keyof typeof REMINDER_PRESETS,
+    options?: { plantId?: string; preferredTime?: string }
+): Promise<Reminder> {
+    const preset = REMINDER_PRESETS[presetKey];
+    return createReminder(growId, preset.type, preset.title, preset.intervalDays, {
+        ...options,
+        description: preset.description
+    });
+}
+
+// ============== NOTIFICATION INITIALIZATION ==============
+
+let checkInterval: ReturnType<typeof setInterval> | null = null;
+
+/**
+ * Initialize notification system with periodic checks
+ * @param intervalMs How often to check for due reminders (default: 60000ms = 1 minute)
+ */
+export function initializeNotifications(intervalMs = 60000): void {
+    // Clear existing interval if any
+    if (checkInterval) {
+        clearInterval(checkInterval);
+    }
+    
+    // Check immediately on init
+    checkDueReminders().catch(console.error);
+    
+    // Set up periodic checks
+    checkInterval = setInterval(() => {
+        checkDueReminders().catch(console.error);
+    }, intervalMs);
+    
+    // Also check on visibility change (when user returns to tab)
+    if (typeof document !== 'undefined') {
+        document.addEventListener('visibilitychange', () => {
+            if (document.visibilityState === 'visible') {
+                checkDueReminders().catch(console.error);
+            }
+        });
+    }
+}
+
+/**
+ * Stop notification checks
+ */
+export function stopNotifications(): void {
+    if (checkInterval) {
+        clearInterval(checkInterval);
+        checkInterval = null;
+    }
+}
+
+// ============== DEFAULT SETTINGS ==============
+
+/**
+ * Get or create default notification settings
+ */
+export async function getOrCreateNotificationSettings(): Promise<NotificationSettings> {
+    const existing = await getNotificationSettings();
+    if (existing) return existing;
+    
+    const defaults: NotificationSettings = {
+        id: 'notification-settings',
+        enabled: false,
+        permission: getNotificationPermission(),
+        defaultReminderTime: '09:00',
+        soundEnabled: true
+    };
+    
+    await saveNotificationSettings(defaults);
+    return defaults;
+}


### PR DESCRIPTION
## Summary
Implements a reminder/notification system for grow tasks (Issue #8).

## Features
- **Browser Notifications**: Request permission and receive native browser notifications
- **Reminder Types**: Watering, Feeding, Photo documentation, Training, Custom
- **Scheduling**: Configurable intervals (daily, every X days, one-time)
- **Presets**: Quick setup with common reminder patterns
- **Per-Grow Management**: Each grow has its own reminders in a dedicated tab

## Changes
- `lib/db.ts`: Added `Reminder` and `NotificationSettings` tables (schema v5)
- `lib/notification-utils.ts`: Core notification logic, permission handling, scheduling
- `components/notifications/`: UI components for settings and reminder management
- `components/settings.tsx`: Added notification settings section
- `components/grow-detail-client.tsx`: Added Reminders tab
- `lib/crypto-utils.ts`: Fixed TypeScript ArrayBuffer compatibility issue

## Screenshots
_UI can be tested in Settings > Notifications and Grow Detail > Reminders tab_

## Testing
- [x] Build passes (`npm run build`)
- [x] Lint passes with only existing warnings
- [ ] Manual testing recommended for notification permissions

Closes #8