### PR TITLE
fix: Improve mobile responsiveness

### DIFF
--- a/components/header.tsx
+++ b/components/header.tsx
@@ -1,20 +1,34 @@
 "use client"
 
 import { Button } from "@/components/ui/button"
-import { Settings } from "lucide-react"
+import { Settings, Menu } from "lucide-react"
 import { useRouting } from "@/hooks/useRouting"
 import Image from "next/image"
+import { useState } from "react"
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu"
 
 export default function Header() {
   const { navigateTo, currentView } = useRouting()
+  const [mobileMenuOpen, setMobileMenuOpen] = useState(false)
+
+  const navItems = [
+    { view: 'dashboard' as const, label: 'Dashboard' },
+    { view: 'grows' as const, label: 'Grows' },
+  ]
 
   return (
     <header className="border-b border-white/10 backdrop-blur-md z-50 w-full">
-      <div className="container max-w-screen-xl mx-auto px-4 py-6 flex justify-between items-center">
-        <div className="flex items-center space-x-8">
+      <div className="container max-w-screen-xl mx-auto px-4 py-4 sm:py-6 flex justify-between items-center">
+        <div className="flex items-center gap-2 sm:gap-8">
+          {/* Logo */}
           <Button
             variant="link"
-            className="text-xl font-bold text-white p-0 h-auto min-w-[48px]"
+            className="text-xl font-bold text-white p-0 h-auto min-w-[40px] sm:min-w-[48px]"
             onClick={() => navigateTo('dashboard')}
           >
             <div className="flex items-center">
@@ -23,29 +37,61 @@ export default function Header() {
                 alt="GrowPanion Logo"
                 width={48}
                 height={48}
-                className="h-10 w-auto mr-2"
+                className="h-8 sm:h-10 w-auto"
               />
             </div>
           </Button>
-          <nav className="flex items-center w-[200px] justify-start">
-            <Button
-              variant="ghost"
-              className={`${currentView === 'dashboard' ? 'text-white bg-gray-800' : 'text-gray-400 hover:text-white'} w-[100px] justify-center`}
-              onClick={() => navigateTo('dashboard')}
-            >
-              Dashboard
-            </Button>
-            <Button
-              variant="ghost"
-              className={`${currentView === 'grows' ? 'text-white bg-gray-800' : 'text-gray-400 hover:text-white'} w-[100px] justify-center`}
-              onClick={() => navigateTo('grows')}
-            >
-              Grows
-            </Button>
+
+          {/* Desktop Navigation */}
+          <nav className="hidden sm:flex items-center gap-1">
+            {navItems.map((item) => (
+              <Button
+                key={item.view}
+                variant="ghost"
+                className={`${
+                  currentView === item.view 
+                    ? 'text-white bg-gray-800' 
+                    : 'text-gray-400 hover:text-white'
+                } px-3`}
+                onClick={() => navigateTo(item.view)}
+              >
+                {item.label}
+              </Button>
+            ))}
           </nav>
+
+          {/* Mobile Navigation */}
+          <div className="sm:hidden">
+            <DropdownMenu open={mobileMenuOpen} onOpenChange={setMobileMenuOpen}>
+              <DropdownMenuTrigger asChild>
+                <Button variant="ghost" size="icon" className="text-gray-400 hover:text-white">
+                  <Menu className="h-5 w-5" />
+                </Button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="start" className="bg-gray-800 border-gray-700">
+                {navItems.map((item) => (
+                  <DropdownMenuItem
+                    key={item.view}
+                    className={`${
+                      currentView === item.view 
+                        ? 'text-white bg-gray-700' 
+                        : 'text-gray-300'
+                    } cursor-pointer`}
+                    onClick={() => {
+                      navigateTo(item.view)
+                      setMobileMenuOpen(false)
+                    }}
+                  >
+                    {item.label}
+                  </DropdownMenuItem>
+                ))}
+              </DropdownMenuContent>
+            </DropdownMenu>
+          </div>
         </div>
 
-        <div className="flex items-center min-w-[40px] justify-end">
+        {/* Settings Button */}
+        <div className="flex items-center">
           <Button
             variant="ghost"
             size="icon"

--- a/components/plant-modal/HSTTab.tsx
+++ b/components/plant-modal/HSTTab.tsx
@@ -65,7 +65,7 @@ const HSTTab: React.FC<TrainingTabProps> = ({
             {/* Fixed input section */}
             <div className="flex-none mb-6">
                 <h3 className="text-xl font-semibold text-green-400 mb-4">Add HST</h3>
-                <div className="grid grid-cols-2 gap-4 mb-4">
+                <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 mb-4">
                     <div>
                         <Label className="text-white">Date</Label>
                         <Input

--- a/components/plant-modal/ImagesTab.tsx
+++ b/components/plant-modal/ImagesTab.tsx
@@ -41,7 +41,7 @@ const ImagesTab: React.FC<ImagesTabProps> = ({
             </div>
 
             {localPlant.images && localPlant.images.length > 0 ? (
-                <div className="grid grid-cols-3 gap-4 w-full">
+                <div className="grid grid-cols-2 sm:grid-cols-3 gap-3 sm:gap-4 w-full">
                     {localPlant.images.map((image, index) => (
                         <div
                             key={index}

--- a/components/plant-modal/InfoTab.tsx
+++ b/components/plant-modal/InfoTab.tsx
@@ -45,7 +45,7 @@ const InfoTab: React.FC<TabComponentProps> = ({ localPlant, setLocalPlant }) => 
                     onChange={handleInputChange}
                 />
             </div>
-            <div className="grid grid-cols-2 gap-4 mb-4">
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 mb-4">
                 <div>
                     <Label className="text-white">
                         Genetic

--- a/components/plant-modal/LSTTab.tsx
+++ b/components/plant-modal/LSTTab.tsx
@@ -65,7 +65,7 @@ const LSTTab: React.FC<TrainingTabProps> = ({
             {/* Fixed input section */}
             <div className="flex-none mb-6">
                 <h3 className="text-xl font-semibold text-green-400 mb-4">Add LST</h3>
-                <div className="grid grid-cols-2 gap-4 mb-4">
+                <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 mb-4">
                     <div>
                         <Label className="text-white">Date</Label>
                         <Input

--- a/components/plant-modal/SubstrateTab.tsx
+++ b/components/plant-modal/SubstrateTab.tsx
@@ -30,7 +30,7 @@ const SubstrateTab: React.FC<SubstrateTabProps> = ({
             {/* Fixed input section */}
             <div className="flex-none mb-6">
                 <h3 className="text-xl font-semibold text-green-400 mb-4">Add Substrate</h3>
-                <div className="grid grid-cols-2 gap-4 mb-4">
+                <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 mb-4">
                     <div>
                         <Label className="text-white">Date</Label>
                         <Input
@@ -53,7 +53,7 @@ const SubstrateTab: React.FC<SubstrateTabProps> = ({
                     </div>
                 </div>
 
-                <div className="grid grid-cols-2 gap-4 mb-4">
+                <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 mb-4">
                     <div>
                         <Label className="text-white">Pot Size</Label>
                         <div className="relative">

--- a/components/plant-modal/WateringFeedingTab.tsx
+++ b/components/plant-modal/WateringFeedingTab.tsx
@@ -50,7 +50,7 @@ const WateringFeedingTab: React.FC<WateringFeedingTabProps & { growId: string }>
             {/* Fixed input section */}
             <div className="flex-none mb-6">
                 <h3 className="text-xl font-semibold text-green-400 mb-4">Add Watering</h3>
-                <div className="grid grid-cols-2 gap-4 mb-4">
+                <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 mb-4">
                     <div>
                         <Label className="text-white">Date</Label>
                         <Input

--- a/components/settings.tsx
+++ b/components/settings.tsx
@@ -451,10 +451,10 @@ export default function SettingsPage() {
 
         // Backwards compatibility for old format
         if (sensor.values.length > 0 && typeof sensor.values[0] === 'string') {
-            // @ts-expect-error - Handling migration from old string[] format
-            setNewSensorValues(sensor.values.join(', '));
-            // @ts-expect-error - Handling migration from old string[] format
-            setValuesToAdd(sensor.values.map(v => ({ code: v })));
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            setNewSensorValues((sensor.values as any[]).join(', '));
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            setValuesToAdd((sensor.values as any[]).map(v => ({ code: v })));
         } else {
             setNewSensorValues(sensor.values.map(v => v.code).join(', '));
         }

--- a/lib/crypto-utils.ts
+++ b/lib/crypto-utils.ts
@@ -29,7 +29,7 @@ async function deriveKey(password: string, salt: Uint8Array): Promise<CryptoKey>
     return crypto.subtle.deriveKey(
         {
             name: 'PBKDF2',
-            salt,
+            salt: salt as BufferSource,
             iterations: ITERATIONS,
             hash: 'SHA-256'
         },
@@ -57,7 +57,7 @@ export async function encrypt(data: string, password: string): Promise<string> {
     
     // Encrypt data
     const ciphertext = await crypto.subtle.encrypt(
-        { name: ALGORITHM, iv },
+        { name: ALGORITHM, iv: iv as BufferSource },
         key,
         dataBuffer
     );
@@ -91,7 +91,7 @@ export async function decrypt(encryptedData: string, password: string): Promise<
     
     // Decrypt data
     const decryptedBuffer = await crypto.subtle.decrypt(
-        { name: ALGORITHM, iv },
+        { name: ALGORITHM, iv: iv as BufferSource },
         key,
         ciphertext
     );


### PR DESCRIPTION
## Summary
Mobile responsiveness improvements based on code analysis.

## Findings & Fixes

### Header (Critical)
**Issue:** Fixed width navigation (w-[200px], w-[100px]) breaks on mobile
**Fix:** 
- Implemented responsive mobile menu with hamburger icon
- Desktop nav shows inline buttons
- Mobile nav shows dropdown menu
- Adjusted logo/nav spacing for smaller screens

### Plant Modal Form Grids
**Issue:** `grid-cols-2` without responsive breakpoints forces 2 columns on tiny screens
**Files fixed:**
- InfoTab.tsx
- WateringFeedingTab.tsx
- HSTTab.tsx
- LSTTab.tsx
- SubstrateTab.tsx

**Fix:** Changed to `grid-cols-1 sm:grid-cols-2`

### Images Tab
**Issue:** `grid-cols-3` too cramped on mobile
**Fix:** Changed to `grid-cols-2 sm:grid-cols-3`

## Also Fixes (Pre-existing)
- Unused @ts-expect-error directives in settings.tsx
- BufferSource type compatibility in crypto-utils.ts

## Testing
- Build passes ✅
- All responsive breakpoints use Tailwind's sm: (640px) breakpoint

Closes bytedr41n/backlog#2