### PR TITLE
feat: Tools Page, UI Fixes (Nightshift #3)

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -7,6 +7,7 @@ import GrowOverview from '@/components/grow-overview'
 import Settings from '@/components/settings'
 import GrowDetailClient from '@/components/grow-detail-client'
 import Statistics from '@/components/statistics'
+import ToolsPage from '@/components/tools-page'
 import { ErrorBoundary } from '@/components/error-boundary'
 import { ScrollArea } from "@/components/ui/scroll-area"
 
@@ -43,6 +44,12 @@ export default function Home() {
         return (
           <ErrorBoundary>
             <Statistics />
+          </ErrorBoundary>
+        );
+      case 'tools':
+        return (
+          <ErrorBoundary>
+            <ToolsPage />
           </ErrorBoundary>
         );
       default:

--- a/components/header.tsx
+++ b/components/header.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import { Button } from "@/components/ui/button"
-import { Settings, Menu, BarChart3 } from "lucide-react"
+import { Settings, Menu } from "lucide-react"
 import { useRouting } from "@/hooks/useRouting"
 import Image from "next/image"
 import { useState } from "react"
@@ -17,9 +17,10 @@ export default function Header() {
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false)
 
   const navItems = [
-    { view: 'dashboard' as const, label: 'Dashboard', icon: null },
-    { view: 'grows' as const, label: 'Grows', icon: null },
-    { view: 'statistics' as const, label: 'Stats', icon: BarChart3 },
+    { view: 'dashboard' as const, label: 'Dashboard' },
+    { view: 'grows' as const, label: 'Grows' },
+    { view: 'statistics' as const, label: 'Stats' },
+    { view: 'tools' as const, label: 'Tools' },
   ]
 
   return (
@@ -56,8 +57,7 @@ export default function Header() {
                 } px-3`}
                 onClick={() => navigateTo(item.view)}
               >
-                {item.icon && <item.icon className="h-4 w-4 mr-1" />}
-                {item.label}
+{item.label}
               </Button>
             ))}
           </nav>
@@ -84,8 +84,7 @@ export default function Header() {
                       setMobileMenuOpen(false)
                     }}
                   >
-                    {item.icon && <item.icon className="h-4 w-4 mr-2" />}
-                    {item.label}
+{item.label}
                   </DropdownMenuItem>
                 ))}
               </DropdownMenuContent>

--- a/components/plant-list.tsx
+++ b/components/plant-list.tsx
@@ -182,7 +182,7 @@ export function PlantList({ growId, plants: providedPlants, isLoading: providedI
                       <Button
                         variant="outline"
                         size="sm"
-                        className="w-full mt-2 border-green-600/50 text-green-400 hover:bg-green-600/20"
+                        className="w-full mt-2 border-green-600/50 text-green-400 hover:bg-green-600/20 rounded-full"
                         onClick={(e) => {
                           e.stopPropagation();
                           setHarvestPlant(plant);

--- a/components/settings.tsx
+++ b/components/settings.tsx
@@ -24,8 +24,6 @@ import {
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { useRouting } from '@/hooks/useRouting';
 import { ExportImportSection } from '@/components/export-import-dialog';
-import { DLICalculator } from '@/components/dli-calculator';
-import HarvestCalculator from '@/components/harvest-calculator/HarvestCalculator';
 import { NotificationSettings } from '@/components/notifications';
 
 const sensorTypes = [
@@ -1013,22 +1011,6 @@ export default function SettingsPage() {
 
                     {/* Export/Import Section */}
                     <ExportImportSection />
-
-                    {/* Tools Section */}
-                    <Card className="bg-gray-800/50 backdrop-filter backdrop-blur-lg border border-gray-700 rounded-2xl text-left">
-                        <CardHeader>
-                            <CardTitle className="text-base sm:text-lg font-medium text-green-400">
-                                Grow Tools
-                            </CardTitle>
-                            <CardDescription className="text-gray-400">
-                                Calculators and utilities for optimizing your grow
-                            </CardDescription>
-                        </CardHeader>
-                        <CardContent className="space-y-6">
-                            <DLICalculator />
-                            <HarvestCalculator />
-                        </CardContent>
-                    </Card>
 
                     {/* Notifications Section */}
                     <NotificationSettings />

--- a/components/tools-page.tsx
+++ b/components/tools-page.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+import { Home } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { useRouting } from '@/hooks/useRouting';
+import { DLICalculator } from '@/components/dli-calculator';
+import HarvestCalculator from '@/components/harvest-calculator/HarvestCalculator';
+
+export default function ToolsPage() {
+    const { navigateTo } = useRouting();
+
+    return (
+        <div className="flex min-h-screen flex-col items-center space-y-8">
+            <div className="w-full">
+                <div className="space-y-8 mt-6">
+                    <div className="flex flex-col sm:flex-row justify-between items-start sm:items-center gap-4">
+                        <div>
+                            <div className="flex items-center gap-2 mb-1">
+                                <Button
+                                    variant="link"
+                                    className="text-gray-400 hover:text-white p-0 h-auto flex items-center gap-1"
+                                    onClick={() => navigateTo('dashboard')}
+                                >
+                                    <Home className="h-4 w-4" />
+                                    <span>Dashboard</span>
+                                </Button>
+                                <span className="text-gray-600">/</span>
+                                <h1 className="font-semibold text-white">Tools</h1>
+                            </div>
+                            <p className="text-gray-400">Calculators and utilities for your grow</p>
+                        </div>
+                    </div>
+
+                    {/* DLI Calculator */}
+                    <DLICalculator />
+
+                    {/* Harvest Yield Calculator */}
+                    <HarvestCalculator />
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/hooks/useRouting.ts
+++ b/hooks/useRouting.ts
@@ -2,7 +2,7 @@
 
 import { useState, useCallback, createContext, useContext, useEffect } from 'react';
 
-export type AppView = 'dashboard' | 'grows' | 'growDetail' | 'settings' | 'statistics';
+export type AppView = 'dashboard' | 'grows' | 'growDetail' | 'settings' | 'statistics' | 'tools';
 
 interface RoutingContextType {
     currentView: AppView;


### PR DESCRIPTION
## Nachtschicht #3 🦇

Closes #16, #17, #18

### Changes

**Issue #16: Tools Page**
- Created dedicated `/tools` route
- Added Tools to navigation (after Stats, before Settings)
- Moved DLI Calculator and Harvest Calculator from Settings
- Settings page now only contains actual settings

**Issue #17: Harvest Button Styling**
- Made Record Harvest button rounded (`rounded-full`)
- Consistent with app design language

**Issue #18: Stats Nav Icon**
- Removed BarChart3 icon from Stats nav item
- All nav items now consistent (no icons)

### Build
- ✅ Build passes
- ✅ Only warnings (existing `<img>` and console statements)